### PR TITLE
Enable Unity PluginAPI support in CI builds

### DIFF
--- a/.github/workflows/build_native_libraries.yaml
+++ b/.github/workflows/build_native_libraries.yaml
@@ -24,8 +24,8 @@ jobs:
       - name: Build
         run: |
           cd projects/CMake
-          cmake -S . -B ./build_x86    -A Win32 -DCMAKE_CXX_STANDARD=17 -DCMAKE_CXX_STANDARD_REQUIRED=ON
-          cmake -S . -B ./build_x86_64 -A x64   -DCMAKE_CXX_STANDARD=17 -DCMAKE_CXX_STANDARD_REQUIRED=ON
+          cmake -S . -B ./build_x86    -A Win32 -DCMAKE_CXX_STANDARD=17 -DCMAKE_CXX_STANDARD_REQUIRED=ON -DUSE_UNITY_PLUGINAPI=ON -DUNITY_PLUGINAPI_DIR="${{ github.workspace }}/dependency/unity-pluginapi"
+          cmake -S . -B ./build_x86_64 -A x64   -DCMAKE_CXX_STANDARD=17 -DCMAKE_CXX_STANDARD_REQUIRED=ON -DUSE_UNITY_PLUGINAPI=ON -DUNITY_PLUGINAPI_DIR="${{ github.workspace }}/dependency/unity-pluginapi"
           cmake --build ./build_x86 --config Release
           cmake --build ./build_x86_64 --config Release
 
@@ -98,15 +98,15 @@ jobs:
           cd projects/CMake
 
           # 1) Build universal (optional, kept because it’s already there)
-          cmake -S . -B ./buildOSX -G Xcode -DRLOTTIE_OSX=1 -DCMAKE_OSX_ARCHITECTURES="x86_64;arm64"
+          cmake -S . -B ./buildOSX -G Xcode -DRLOTTIE_OSX=1 -DCMAKE_OSX_ARCHITECTURES="x86_64;arm64" -DUSE_UNITY_PLUGINAPI=ON -DUNITY_PLUGINAPI_DIR="$GITHUB_WORKSPACE/dependency/unity-pluginapi"
           cmake --build ./buildOSX --config Release 
 
           # 2) Build arm64 only
-          cmake -S . -B ./buildOSX_arm64 -G Xcode -DRLOTTIE_OSX=1 -DCMAKE_OSX_ARCHITECTURES=arm64
+          cmake -S . -B ./buildOSX_arm64 -G Xcode -DRLOTTIE_OSX=1 -DCMAKE_OSX_ARCHITECTURES=arm64 -DUSE_UNITY_PLUGINAPI=ON -DUNITY_PLUGINAPI_DIR="$GITHUB_WORKSPACE/dependency/unity-pluginapi"
           cmake --build ./buildOSX_arm64 --config Release
 
           # 3) Build x86_64 only
-          cmake -S . -B ./buildOSX_x86_64 -G Xcode -DRLOTTIE_OSX=1 -DCMAKE_OSX_ARCHITECTURES=x86_64
+          cmake -S . -B ./buildOSX_x86_64 -G Xcode -DRLOTTIE_OSX=1 -DCMAKE_OSX_ARCHITECTURES=x86_64 -DUSE_UNITY_PLUGINAPI=ON -DUNITY_PLUGINAPI_DIR="$GITHUB_WORKSPACE/dependency/unity-pluginapi"
           cmake --build ./buildOSX_x86_64 --config Release
 
           # 4) Find actual outputs produced by Xcode/CMake
@@ -164,7 +164,7 @@ jobs:
       - name: Build
         run: |
           cd projects/CMake
-          cmake -S . -B ./buildIOS -G Xcode -DCMAKE_TOOLCHAIN_FILE=../../dependency/cmake-ios-toolchain/ios.toolchain.cmake -DPLATFORM=OS64 -DRLOTTIE_IOS=1
+          cmake -S . -B ./buildIOS -G Xcode -DCMAKE_TOOLCHAIN_FILE=../../dependency/cmake-ios-toolchain/ios.toolchain.cmake -DPLATFORM=OS64 -DRLOTTIE_IOS=1 -DUSE_UNITY_PLUGINAPI=ON -DUNITY_PLUGINAPI_DIR="$GITHUB_WORKSPACE/dependency/unity-pluginapi"
           cmake --build ./buildIOS --config Release --target LottiePlugin
           brew install tree
           tree ../../out
@@ -201,7 +201,9 @@ jobs:
             -DCMAKE_TOOLCHAIN_FILE=../../dependency/cmake-ios-toolchain/ios.toolchain.cmake \
             -DPLATFORM=SIMULATOR64 \
             -DARCHS=x86_64 \
-            -DRLOTTIE_IOS=1
+            -DRLOTTIE_IOS=1 \
+            -DUSE_UNITY_PLUGINAPI=ON \
+            -DUNITY_PLUGINAPI_DIR="$GITHUB_WORKSPACE/dependency/unity-pluginapi"
           cmake --build ./buildIOSSim_x64 --config Release --target LottiePlugin
           brew install tree
           tree ../../out || true
@@ -223,22 +225,24 @@ jobs:
         with:
           submodules: recursive
 
-      - name: Install CMake
-        run: sudo apt-get install cmake
+      - name: Install deps
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y cmake build-essential mesa-common-dev libgl1-mesa-dev tree
 
       - name: Build
         run: |
           cd projects/CMake
-          cmake -S . -B ./buildLinux -G "Unix Makefiles" -DRLOTTIE_LINUX=1
+          cmake -S . -B ./buildLinux -G "Unix Makefiles" -DRLOTTIE_LINUX=1 -DCMAKE_BUILD_TYPE=Release -DUSE_UNITY_PLUGINAPI=ON -DUNITY_PLUGINAPI_DIR="${GITHUB_WORKSPACE}/dependency/unity-pluginapi"
           cmake --build ./buildLinux --config Release
-          tree ../../out
+          tree ../../out || true
 
       - name: Upload artifacts
         uses: actions/upload-artifact@v4
         with:
           name: LottiePluginLinuxArtifacts
           path: |
-            out/Plugins/Linux/x86_64/libLottiePlugin.so
+            out/Release/Plugins/Linux/x86_64/libLottiePlugin.so
 
   build_webgl:
     runs-on: ubuntu-latest
@@ -414,7 +418,7 @@ jobs:
           mkdir -p unity/RLottieUnity/Assets/LottiePlugin/Plugins/iOS/x86_64
           cp -f out/Plugins/iOS/x86_64/libLottiePlugin.a unity/RLottieUnity/Assets/LottiePlugin/Plugins/iOS/x86_64/libLottiePlugin.a
           cp -f out/Plugins/iOS/x86_64/librlottie.a     unity/RLottieUnity/Assets/LottiePlugin/Plugins/iOS/x86_64/librlottie.a
-          cp -f out/Plugins/Linux/libLottiePlugin.so unity/RLottieUnity/Assets/LottiePlugin/Plugins/Linux/x86_64/libLottiePlugin.so
+          cp -f out/Release/Plugins/Linux/x86_64/libLottiePlugin.so unity/RLottieUnity/Assets/LottiePlugin/Plugins/Linux/x86_64/libLottiePlugin.so
           mkdir -p unity/RLottieUnity/Assets/LottiePlugin/Plugins/WebGL
           cp -f out/Plugins/WebGL/libLottiePlugin.a unity/RLottieUnity/Assets/LottiePlugin/Plugins/WebGL/libLottiePlugin.a
           cp -f out/Plugins/WebGL/librlottie.a     unity/RLottieUnity/Assets/LottiePlugin/Plugins/WebGL/librlottie.a

--- a/dependency/unity-pluginapi/IUnityInterface.h
+++ b/dependency/unity-pluginapi/IUnityInterface.h
@@ -1,0 +1,206 @@
+// Unity Native Plugin API copyright © 2015 Unity Technologies ApS
+//
+// Licensed under the Unity Companion License for Unity - dependent projects--see[Unity Companion License](http://www.unity3d.com/legal/licenses/Unity_Companion_License).
+//
+// Unless expressly provided otherwise, the Software under this license is made available strictly on an “AS IS” BASIS WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED.Please review the license for details on these and other terms and conditions.
+
+#pragma once
+
+// Unity native plugin API
+// Compatible with C99
+
+#if defined(__CYGWIN32__)
+    #define UNITY_INTERFACE_API __stdcall
+    #define UNITY_INTERFACE_EXPORT __declspec(dllexport)
+#elif defined(WIN32) || defined(_WIN32) || defined(__WIN32__) || defined(_WIN64) || defined(WINAPI_FAMILY)
+    #define UNITY_INTERFACE_API __stdcall
+    #define UNITY_INTERFACE_EXPORT __declspec(dllexport)
+#elif defined(__MACH__) || defined(__ANDROID__) || defined(__linux__) || defined(LUMIN)
+    #define UNITY_INTERFACE_API
+    #define UNITY_INTERFACE_EXPORT __attribute__ ((visibility ("default")))
+#else
+    #define UNITY_INTERFACE_API
+    #define UNITY_INTERFACE_EXPORT
+#endif
+
+/////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+// IUnityInterface is a registry of interfaces we choose to expose to plugins.
+//
+// USAGE:
+// ---------
+// To retrieve an interface a user can do the following from a plugin, assuming they have the header file for the interface:
+//
+// IMyInterface * ptr = registry->Get<IMyInterface>();
+/////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+// Unity Interface GUID
+// Ensures global uniqueness.
+//
+// Template specialization is used to produce a means of looking up a GUID from its interface type at compile time.
+// The net result should compile down to passing around the GUID.
+//
+// UNITY_REGISTER_INTERFACE_GUID should be placed in the header file of any interface definition outside of all namespaces.
+// The interface structure and the registration GUID are all that is required to expose the interface to other systems.
+struct UnityInterfaceGUID
+{
+#ifdef __cplusplus
+    UnityInterfaceGUID(unsigned long long high, unsigned long long low)
+        : m_GUIDHigh(high)
+        , m_GUIDLow(low)
+    {
+    }
+
+    UnityInterfaceGUID(const UnityInterfaceGUID& other)
+    {
+        m_GUIDHigh = other.m_GUIDHigh;
+        m_GUIDLow  = other.m_GUIDLow;
+    }
+
+    UnityInterfaceGUID& operator=(const UnityInterfaceGUID& other)
+    {
+        m_GUIDHigh = other.m_GUIDHigh;
+        m_GUIDLow  = other.m_GUIDLow;
+        return *this;
+    }
+
+    bool Equals(const UnityInterfaceGUID& other)   const { return m_GUIDHigh == other.m_GUIDHigh && m_GUIDLow == other.m_GUIDLow; }
+    bool LessThan(const UnityInterfaceGUID& other) const { return m_GUIDHigh < other.m_GUIDHigh || (m_GUIDHigh == other.m_GUIDHigh && m_GUIDLow < other.m_GUIDLow); }
+#endif
+    unsigned long long m_GUIDHigh;
+    unsigned long long m_GUIDLow;
+};
+#ifdef __cplusplus
+inline bool operator==(const UnityInterfaceGUID& left, const UnityInterfaceGUID& right) { return left.Equals(right); }
+inline bool operator!=(const UnityInterfaceGUID& left, const UnityInterfaceGUID& right) { return !left.Equals(right); }
+inline bool operator<(const UnityInterfaceGUID& left, const UnityInterfaceGUID& right) { return left.LessThan(right); }
+inline bool operator>(const UnityInterfaceGUID& left, const UnityInterfaceGUID& right) { return right.LessThan(left); }
+inline bool operator>=(const UnityInterfaceGUID& left, const UnityInterfaceGUID& right) { return !operator<(left, right); }
+inline bool operator<=(const UnityInterfaceGUID& left, const UnityInterfaceGUID& right) { return !operator>(left, right); }
+#else
+typedef struct UnityInterfaceGUID UnityInterfaceGUID;
+#endif
+
+
+#ifdef __cplusplus
+    #define UNITY_DECLARE_INTERFACE(NAME) \
+    struct NAME : IUnityInterface
+
+// Generic version of GetUnityInterfaceGUID to allow us to specialize it
+// per interface below. The generic version has no actual implementation
+// on purpose.
+//
+// If you get errors about return values related to this method then
+// you have forgotten to include UNITY_REGISTER_INTERFACE_GUID with
+// your interface, or it is not visible at some point when you are
+// trying to retrieve or add an interface.
+template<typename TYPE>
+inline const UnityInterfaceGUID GetUnityInterfaceGUID();
+
+// This is the macro you provide in your public interface header
+// outside of a namespace to allow us to map between type and GUID
+// without the user having to worry about it when attempting to
+// add or retrieve and interface from the registry.
+    #define UNITY_REGISTER_INTERFACE_GUID(HASHH, HASHL, TYPE)      \
+    template<>                                                     \
+    inline const UnityInterfaceGUID GetUnityInterfaceGUID<TYPE>()  \
+    {                                                              \
+        return UnityInterfaceGUID(HASHH,HASHL);                    \
+    }
+
+// Same as UNITY_REGISTER_INTERFACE_GUID but allows the interface to live in
+// a particular namespace. As long as the namespace is visible at the time you call
+// GetUnityInterfaceGUID< INTERFACETYPE >() or you explicitly qualify it in the template
+// calls this will work fine, only the macro here needs to have the additional parameter
+    #define UNITY_REGISTER_INTERFACE_GUID_IN_NAMESPACE(HASHH, HASHL, TYPE, NAMESPACE) \
+    const UnityInterfaceGUID TYPE##_GUID(HASHH, HASHL);                               \
+    template<>                                                                        \
+    inline const UnityInterfaceGUID GetUnityInterfaceGUID< NAMESPACE :: TYPE >()      \
+    {                                                                                 \
+        return UnityInterfaceGUID(HASHH,HASHL);                                       \
+    }
+
+// These macros allow for C compatibility in user code.
+    #define UNITY_GET_INTERFACE_GUID(TYPE) GetUnityInterfaceGUID< TYPE >()
+
+
+#else
+    #define UNITY_DECLARE_INTERFACE(NAME) \
+    typedef struct NAME NAME;             \
+    struct NAME
+
+// NOTE: This has the downside that one some compilers it will not get stripped from all compilation units that
+//       can see a header containing this constant. However, it's only for C compatibility and thus should have
+//       minimal impact.
+    #define UNITY_REGISTER_INTERFACE_GUID(HASHH, HASHL, TYPE) \
+    const UnityInterfaceGUID TYPE##_GUID = {HASHH, HASHL};
+
+// In general namespaces are going to be a problem for C code any interfaces we expose in a namespace are
+// not going to be usable from C.
+    #define UNITY_REGISTER_INTERFACE_GUID_IN_NAMESPACE(HASHH, HASHL, TYPE, NAMESPACE)
+
+// These macros allow for C compatibility in user code.
+    #define UNITY_GET_INTERFACE_GUID(TYPE) TYPE##_GUID
+#endif
+
+// Using this in user code rather than INTERFACES->Get<TYPE>() will be C compatible for those places in plugins where
+// this may be needed. Unity code itself does not need this.
+#define UNITY_GET_INTERFACE(INTERFACES, TYPE) (TYPE*)INTERFACES->GetInterfaceSplit (UNITY_GET_INTERFACE_GUID(TYPE).m_GUIDHigh, UNITY_GET_INTERFACE_GUID(TYPE).m_GUIDLow);
+
+
+#ifdef __cplusplus
+struct IUnityInterface
+{
+};
+#else
+typedef void IUnityInterface;
+#endif
+
+
+typedef struct IUnityInterfaces
+{
+    // Returns an interface matching the guid.
+    // Returns nullptr if the given interface is unavailable in the active Unity runtime.
+    IUnityInterface* (UNITY_INTERFACE_API * GetInterface)(UnityInterfaceGUID guid);
+
+    // Registers a new interface.
+    void(UNITY_INTERFACE_API * RegisterInterface)(UnityInterfaceGUID guid, IUnityInterface * ptr);
+
+    // Split APIs for C
+    IUnityInterface* (UNITY_INTERFACE_API * GetInterfaceSplit)(unsigned long long guidHigh, unsigned long long guidLow);
+    void(UNITY_INTERFACE_API * RegisterInterfaceSplit)(unsigned long long guidHigh, unsigned long long guidLow, IUnityInterface * ptr);
+
+#ifdef __cplusplus
+    // Helper for GetInterface.
+    template<typename INTERFACE>
+    INTERFACE* Get()
+    {
+        return static_cast<INTERFACE*>(GetInterface(GetUnityInterfaceGUID<INTERFACE>()));
+    }
+
+    // Helper for RegisterInterface.
+    template<typename INTERFACE>
+    void Register(IUnityInterface* ptr)
+    {
+        RegisterInterface(GetUnityInterfaceGUID<INTERFACE>(), ptr);
+    }
+
+#endif
+} IUnityInterfaces;
+
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+// If exported by a plugin, this function will be called when the plugin is loaded.
+void UNITY_INTERFACE_EXPORT UNITY_INTERFACE_API UnityPluginLoad(IUnityInterfaces* unityInterfaces);
+// If exported by a plugin, this function will be called when the plugin is about to be unloaded.
+void UNITY_INTERFACE_EXPORT UNITY_INTERFACE_API UnityPluginUnload();
+
+#ifdef __cplusplus
+}
+#endif
+
+struct RenderSurfaceBase;
+typedef struct RenderSurfaceBase* UnityRenderBuffer;
+typedef unsigned int UnityTextureID;

--- a/dependency/unity-pluginapi/IUnityProfiler.h
+++ b/dependency/unity-pluginapi/IUnityProfiler.h
@@ -1,0 +1,273 @@
+// Unity Native Plugin API copyright © 2015 Unity Technologies ApS
+//
+// Licensed under the Unity Companion License for Unity - dependent projects--see[Unity Companion License](http://www.unity3d.com/legal/licenses/Unity_Companion_License).
+//
+// Unless expressly provided otherwise, the Software under this license is made available strictly on an “AS IS” BASIS WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED.Please review the license for details on these and other terms and conditions.
+
+#pragma once
+#include "IUnityInterface.h"
+
+#include <stdint.h>
+
+// Unity Profiler Native plugin API provides an ability to register callbacks for Unity Profiler events.
+// The basic functionality includes:
+// 1. Ability to create a Unity Profiler Marker.
+// 2. Begin and end sample.
+// 3. Register a thread for profiling.
+// 4. Obtain an information if profiler is available and enabled.
+//
+//  Usage example:
+//
+//  #include <IUnityInterface.h>
+//  #include <IUnityProfiler.h>
+//
+//  static IUnityProfiler* s_UnityProfiler = NULL;
+//  static const UnityProfilerMarkerDesc* s_MyPluginMarker = NULL;
+//  static bool s_IsDevelopmentBuild = false;
+//
+//  static void MyPluginWorkMethod()
+//  {
+//      if (s_IsDevelopmentBuild)
+//          s_UnityProfiler->BeginSample(s_MyPluginMarker);
+//
+//      // Code I want to see in Unity Profiler as "MyPluginMethod".
+//      // ...
+//
+//      if (s_IsDevelopmentBuild)
+//          s_UnityProfiler->EndSample(s_MyPluginMarker);
+//  }
+//
+//  extern "C" void UNITY_INTERFACE_EXPORT UNITY_INTERFACE_API UnityPluginLoad(IUnityInterfaces* unityInterfaces)
+//  {
+//      s_UnityProfiler = unityInterfaces->Get<IUnityProfiler>();
+//      if (s_UnityProfiler == NULL)
+//          return;
+//      s_IsDevelopmentBuild = s_UnityProfiler->IsAvailable() != 0;
+//      s_UnityProfiler->CreateMarker(&s_MyPluginMarker, "MyPluginMethod", kUnityProfilerCategoryOther, kUnityProfilerMarkerFlagDefault, 0);
+//  }
+//
+//  extern "C" void UNITY_INTERFACE_EXPORT UNITY_INTERFACE_API UnityPluginUnload()
+//  {
+//  }
+
+
+typedef uint32_t UnityProfilerMarkerId;
+
+enum UnityBuiltinProfilerCategory_
+{
+    kUnityProfilerCategoryRender = 0,
+    kUnityProfilerCategoryScripts = 1,
+    kUnityProfilerCategoryManagedJobs = 2,
+    kUnityProfilerCategoryBurstJobs = 3,
+    kUnityProfilerCategoryGUI = 4,
+    kUnityProfilerCategoryPhysics = 5,
+    kUnityProfilerCategoryAnimation = 6,
+    kUnityProfilerCategoryAI = 7,
+    kUnityProfilerCategoryAudio = 8,
+    kUnityProfilerCategoryAudioJob = 9,
+    kUnityProfilerCategoryAudioUpdateJob = 10,
+    kUnityProfilerCategoryVideo = 11,
+    kUnityProfilerCategoryParticles = 12,
+    kUnityProfilerCategoryGi = 13,
+    kUnityProfilerCategoryNetwork = 14,
+    kUnityProfilerCategoryLoading = 15,
+    kUnityProfilerCategoryOther = 16,
+    kUnityProfilerCategoryGC = 17,
+    kUnityProfilerCategoryVSync = 18,
+    kUnityProfilerCategoryOverhead = 19,
+    kUnityProfilerCategoryPlayerLoop = 20,
+    kUnityProfilerCategoryDirector = 21,
+    kUnityProfilerCategoryVR = 22,
+    kUnityProfilerCategoryAllocation = 23, kUnityProfilerCategoryMemory = 23,
+    kUnityProfilerCategoryInternal = 24,
+    kUnityProfilerCategoryFileIO = 25,
+    kUnityProfilerCategoryUISystemLayout = 26,
+    kUnityProfilerCategoryUISystemRender = 27,
+    kUnityProfilerCategoryVFX = 28,
+    kUnityProfilerCategoryBuildInterface = 29,
+    kUnityProfilerCategoryInput = 30,
+    kUnityProfilerCategoryVirtualTexturing = 31,
+};
+typedef uint16_t UnityProfilerCategoryId;
+
+typedef struct UnityProfilerCategoryDesc
+{
+    // Incremental category index.
+    UnityProfilerCategoryId id;
+    // Reserved.
+    uint16_t reserved0;
+    // Internally associated category color which is in 0xRRGGBBAA format.
+    uint32_t rgbaColor;
+    // NULL-terminated string which is associated with the category.
+    const char* name;
+} UnityProfilerCategoryDesc;
+
+enum UnityProfilerMarkerFlag_
+{
+    kUnityProfilerMarkerFlagDefault = 0,
+
+    kUnityProfilerMarkerFlagScriptUser = 1 << 1,         // Markers created with C# API.
+    kUnityProfilerMarkerFlagScriptInvoke = 1 << 5,       // Runtime invocations with ScriptingInvocation::Invoke.
+    kUnityProfilerMarkerFlagScriptEnterLeave = 1 << 6,   // Deep profiler.
+
+    kUnityProfilerMarkerFlagAvailabilityEditor = 1 << 2, // Editor-only marker, doesn't present in dev and non-dev players.
+    kUnityProfilerMarkerFlagAvailabilityNonDev = 1 << 3, // Non-development marker, is present everywhere including release builds.
+
+    kUnityProfilerMarkerFlagWarning = 1 << 4,            // Indicates undesirable, performance-wise suboptimal code path.
+
+    kCounter = 1 << 7,                                   // Marker is also used as a counter.
+    kUnityProfilerMarkerFlagCounter = kCounter,
+
+    kUnityProfilerMarkerFlagVerbosityDebug = 1 << 10,    // Internal debug markers - e.g. JobSystem Idle.
+    kUnityProfilerMarkerFlagVerbosityInternal = 1 << 11, // Internal markers - e.g. Mutex/semaphore waits.
+    kUnityProfilerMarkerFlagVerbosityAdvanced = 1 << 12  // Markers which are useful for advanced users - e.g. Loading.
+};
+typedef uint16_t UnityProfilerMarkerFlags;
+
+enum UnityProfilerMarkerEventType_
+{
+    kUnityProfilerMarkerEventTypeBegin = 0,
+    kUnityProfilerMarkerEventTypeEnd = 1,
+    kUnityProfilerMarkerEventTypeSingle = 2
+};
+typedef uint16_t UnityProfilerMarkerEventType;
+
+typedef struct UnityProfilerMarkerDesc
+{
+    // Per-marker callback chain pointer. Don't use.
+    const void* callback;
+    // Event id.
+    UnityProfilerMarkerId id;
+    // UnityProfilerMarkerFlag_ value.
+    UnityProfilerMarkerFlags flags;
+    // Category index the marker belongs to.
+    UnityProfilerCategoryId categoryId;
+    // NULL-terminated string which is associated with the marker.
+    const char* name;
+    // Metadata descriptions chain. Don't use.
+    const void* metaDataDesc;
+} UnityProfilerMarkerDesc;
+
+enum UnityProfilerMarkerDataType_
+{
+    kUnityProfilerMarkerDataTypeNone = 0,
+    kUnityProfilerMarkerDataTypeInstanceId = 1,
+    kUnityProfilerMarkerDataTypeInt32 = 2,
+    kUnityProfilerMarkerDataTypeUInt32 = 3,
+    kUnityProfilerMarkerDataTypeInt64 = 4,
+    kUnityProfilerMarkerDataTypeUInt64 = 5,
+    kUnityProfilerMarkerDataTypeFloat = 6,
+    kUnityProfilerMarkerDataTypeDouble = 7,
+    kUnityProfilerMarkerDataTypeString = 8,
+    kUnityProfilerMarkerDataTypeString16 = 9,
+    kUnityProfilerMarkerDataTypeBlob8 = 11,
+    kUnityProfilerMarkerDataTypeCount // Total count of data types
+};
+typedef uint8_t UnityProfilerMarkerDataType;
+
+enum UnityProfilerMarkerDataUnit_
+{
+    kUnityProfilerMarkerDataUnitUndefined = 0,
+    kUnityProfilerMarkerDataUnitTimeNanoseconds = 1,
+    kUnityProfilerMarkerDataUnitBytes = 2,
+    kUnityProfilerMarkerDataUnitCount = 3,
+    kUnityProfilerMarkerDataUnitPercent = 4,
+    kUnityProfilerMarkerDataUnitFrequencyHz = 5,
+};
+typedef uint8_t UnityProfilerMarkerDataUnit;
+
+typedef struct UnityProfilerMarkerData
+{
+    UnityProfilerMarkerDataType type;
+    uint8_t reserved0;
+    uint16_t reserved1;
+    uint32_t size;
+    const void* ptr;
+} UnityProfilerMarkerData;
+
+enum UnityProfilerFlowEventType_
+{
+    // Starts flow chain for a current profiler marker scope (__enclosing__ scope).
+    // Mark the scheduler function with "begin" flow to connect it later to execution function on another thread.
+    kUnityProfilerFlowEventTypeBegin = 0,
+    // The flow continues with the next sample.
+    // Marks the __next__ profiler sample connected to the sample which started the flow (kUnityProfilerFlowEventTypeBegin) or previous (in time) kUnityProfilerFlowEventTypeNext flow event.
+    // All parallel flow instances are equivalent and connected to the same previous in time kUnityProfilerFlowEventTypeBegin or kUnityProfilerFlowEventTypeNext events and next (also in time) kUnityProfilerFlowEventTypeNext event.
+    kUnityProfilerFlowEventTypeParallelNext = 1,
+    // Ends flow started by kUnityProfilerFlowEventTypeBegin. Usually represents a sync point (SyncFence)
+    // Marks the __enclosing__ sample as endpoint.
+    kUnityProfilerFlowEventTypeEnd = 2,
+    // The flow continues with the next sample.
+    // Marks the __next__ profiler sample connected to the sample which started the flow (kUnityProfilerFlowEventTypeBegin).
+    kUnityProfilerFlowEventTypeNext = 3,
+};
+typedef uint8_t UnityProfilerFlowEventType;
+
+typedef uint64_t UnityProfilerThreadId;
+
+// Available since 2020.1
+UNITY_DECLARE_INTERFACE(IUnityProfiler)
+{
+    void BeginSample(const UnityProfilerMarkerDesc* markerDesc)
+    {
+        (this->EmitEvent)(markerDesc, kUnityProfilerMarkerEventTypeBegin, 0, NULL);
+    }
+
+    void BeginSample(const UnityProfilerMarkerDesc* markerDesc, uint16_t eventDataCount, const UnityProfilerMarkerData* eventData)
+    {
+        (this->EmitEvent)(markerDesc, kUnityProfilerMarkerEventTypeBegin, eventDataCount, eventData);
+    }
+
+    void EndSample(const UnityProfilerMarkerDesc* markerDesc)
+    {
+        (this->EmitEvent)(markerDesc, kUnityProfilerMarkerEventTypeEnd, 0, NULL);
+    }
+
+    // Create instrumentation event.
+    // \param markerDesc is a pointer to marker description struct.
+    // \param eventType is an event type - UnityProfilerMarkerEventType_.
+    // \param eventDataCount is an event metadata count passed in eventData. Must be less than eventDataCount specified in CreateMarker.
+    // \param eventData is a metadata array of eventDataCount elements.
+    void(UNITY_INTERFACE_API * EmitEvent)(const UnityProfilerMarkerDesc* markerDesc, UnityProfilerMarkerEventType eventType, uint16_t eventDataCount, const UnityProfilerMarkerData* eventData);
+
+    // Returns 1 if Unity Profiler is enabled, 0 overwise.
+    int(UNITY_INTERFACE_API * IsEnabled)();
+
+    // Returns 1 if Unity Profiler is available, 0 overwise.
+    // Profiler is available only in Development builds. Release builds have Unity Profiler compiled out.
+    // However individual markers can be available even in Release builds (e.g. GC.Collect) and be collected with
+    // Recorder API or forwarded to platform and other profilers (via IUnityProfilerCallbacks::RegisterMarkerEventCallback API).
+    // You can choose whenever you want or not emit profiler event in Development and Release builds using the cached result of this method.
+    int(UNITY_INTERFACE_API * IsAvailable)();
+
+    // Creates a new Unity Profiler marker.
+    // \param desc Pointer to the const UnityProfilerMarkerDesc* which is set to the created marker in a case of a succesful execution.
+    // \param name Marker name to be displayed in Unity Profiler.
+    // \param flags Marker flags. One of UnityProfilerMarkerFlag_ enum. Use kUnityProfilerMarkerFlagDefault if not sure.
+    // \param eventDataCount Maximum count of potential metadata parameters count.
+    // \return 0 on success and non-zero in case of error.
+    int(UNITY_INTERFACE_API * CreateMarker)(const UnityProfilerMarkerDesc** desc, const char* name, UnityProfilerCategoryId category, UnityProfilerMarkerFlags flags, int eventDataCount);
+
+    // Set a metadata description for the Unity Profiler marker.
+    // \param markerDesc is a pointer to marker description struct.
+    // \param index metadata index to set name for.
+    // \param metadataType Data type. Must be of UnityProfilerMarkerDataType_ enum.
+    // \param name Metadata name.
+    // \return 0 on success and non-zero in case of error.
+    int(UNITY_INTERFACE_API * SetMarkerMetadataName)(const UnityProfilerMarkerDesc* desc, int index, const char* metadataName, UnityProfilerMarkerDataType metadataType, UnityProfilerMarkerDataUnit metadataUnit);
+
+    // Registers current thread with Unity Profiler.
+    // Has no effect in Release Players.
+    // \param threadId Optional Unity Profiler thread identifier which it written on successful method call. Can be used with UnregisterThread.
+    // \param groupName Thread group name. Unity Profiler aggregates threads with the same group.
+    // \param name Thread name.
+    // \return 0 on success and non-zero in case of error.
+    int(UNITY_INTERFACE_API * RegisterThread)(UnityProfilerThreadId* threadId, const char* groupName, const char* name);
+
+    // Unregisters current thread from Unity Profiler and cleans up all associated memory.
+    // Has no effect in Release Players.
+    // \param threadId Unity Profiler thread identifier obtained with RegisterThread call. Use 0 to cleanup the current thread.
+    // \return 0 on success and non-zero in case of error.
+    int(UNITY_INTERFACE_API * UnregisterThread)(UnityProfilerThreadId threadId);
+};
+UNITY_REGISTER_INTERFACE_GUID(0x2CE79ED8316A4833ULL, 0x87076B2013E1571FULL, IUnityProfiler)

--- a/projects/CMake/CMakeLists.txt
+++ b/projects/CMake/CMakeLists.txt
@@ -5,6 +5,8 @@ cmake_minimum_required (VERSION 3.16)
 project(LottiePlugin)
 
 option(RLOTTIE_ANDROID_PAGE_SIZE_16K "Build Android libraries with 16KB page size" OFF)
+option(USE_UNITY_PLUGINAPI "Use Unity PluginAPI headers (IUnityInterface.h/IUnityProfiler.h)" ON)
+set(UNITY_PLUGINAPI_DIR "${CMAKE_CURRENT_LIST_DIR}/../../dependency/unity-pluginapi" CACHE PATH "Path to Unity PluginAPI headers")
 
 set(BUILD_SHARED_LIBS FALSE)
 set(CMAKE_POSITION_INDEPENDENT_CODE TRUE)
@@ -44,8 +46,11 @@ endif()
 add_subdirectory(${RLOTTIE_ROOT} ${CMAKE_CURRENT_BINARY_DIR}/rlottie_build)
 # Make rlottie compile as C++17 (doesn't affect your plugin target)
 target_compile_features(rlottie PUBLIC cxx_std_17)
-
 target_compile_definitions(rlottie PRIVATE LOTTIE_LOGGING_SUPPORT)
+if (MSVC)
+    target_compile_definitions(rlottie PRIVATE _CRT_SECURE_NO_WARNINGS)
+endif()
+
 include_directories ($<BUILD_INTERFACE:${RLOTTIE_ROOT}/inc> ${RLOTTIE_ROOT}/src/vector/ ${RLOTTIE_ROOT}/vs2019/)
 message("Lottie root directory: ${RLOTTIE_ROOT}")
 
@@ -97,29 +102,40 @@ if(MSVC)
                             /Zc:__cplusplus # enable C++17 features
                             /permissive-) # standards compliant mode
     target_compile_options(LottiePlugin
-                        PUBLIC
                         PRIVATE
                             /std:c++17
-                            /EHsc- # disable exceptions
+                            /EHsc # enable exceptions
                             /Zc:__cplusplus # enable C++17 features
                             /permissive- # standards compliant mode
                             /W3 # warning level
                         )
 else()
     target_compile_options(LottiePlugin
-                        PUBLIC
                         PRIVATE
                             -std=c++17
-                            -fno-exceptions
-                            -fno-unwind-tables
-                            -fno-asynchronous-unwind-tables
-                            -fno-rtti
                             -Wall
                             -fvisibility=hidden
                             -Wnon-virtual-dtor
                             -Woverloaded-virtual
                             -Wno-unused-parameter
                         )
+    if (RLOTTIE_WEB_ASSEMBLY OR ANDROID)
+        target_compile_options(LottiePlugin
+                            PRIVATE
+                                -fno-exceptions
+                                -fno-unwind-tables
+                                -fno-asynchronous-unwind-tables
+                                -fno-rtti)
+    endif()
+endif()
+
+if (USE_UNITY_PLUGINAPI)
+    if (EXISTS "${UNITY_PLUGINAPI_DIR}/IUnityInterface.h" AND EXISTS "${UNITY_PLUGINAPI_DIR}/IUnityProfiler.h")
+        target_include_directories(LottiePlugin PRIVATE "${UNITY_PLUGINAPI_DIR}")
+        target_compile_definitions(LottiePlugin PRIVATE HAVE_UNITY_PLUGINAPI=1)
+    else()
+        message(FATAL_ERROR "USE_UNITY_PLUGINAPI=ON but Unity headers not found in '${UNITY_PLUGINAPI_DIR}'")
+    endif()
 endif()
 
 add_dependencies(LottiePlugin rlottie)

--- a/src/LottiePlugin.cpp
+++ b/src/LottiePlugin.cpp
@@ -14,7 +14,7 @@
 #include <utility>
 #include <vector>
 
-#if !defined(__EMSCRIPTEN__)
+#if defined(HAVE_UNITY_PLUGINAPI) && !defined(__EMSCRIPTEN__)
 #    include "IUnityInterface.h"
 #    include "IUnityProfiler.h"
 
@@ -74,7 +74,7 @@ static UnityProfilerMarkerDesc* sMkUpload = nullptr;
 
 namespace
 {
-#if !defined(__EMSCRIPTEN__)
+#if defined(HAVE_UNITY_PLUGINAPI) && !defined(__EMSCRIPTEN__)
     struct UploadContext
     {
         const uint8_t* data = nullptr;
@@ -856,7 +856,7 @@ extern "C"
 
     extern "C" void UNITY_INTERFACE_EXPORT UNITY_INTERFACE_API UnityPluginLoad(void* unityInterfaces)
     {
-#if !defined(__EMSCRIPTEN__)
+#if defined(HAVE_UNITY_PLUGINAPI) && !defined(__EMSCRIPTEN__)
         auto* ifaces = static_cast<IUnityInterfaces*>(unityInterfaces);
         sProfiler = ifaces != nullptr ? ifaces->Get<IUnityProfiler>() : nullptr;
         if (sProfiler != nullptr && sProfiler->IsAvailable())
@@ -899,7 +899,7 @@ extern "C"
             std::swap(gPendingUploads, empty);
         }
 
-#if !defined(__EMSCRIPTEN__)
+#if defined(HAVE_UNITY_PLUGINAPI) && !defined(__EMSCRIPTEN__)
         sProfiler = nullptr;
         sMkGetResult = nullptr;
         sMkPublish = nullptr;


### PR DESCRIPTION
## Summary
- vendor Unity PluginAPI headers so builds have access to IUnityInterface/IUnityProfiler definitions
- update CMake to consume the headers, align exception flags, and fail fast when headers are missing
- guard profiler code on the new definition and extend CI workflows to pass the include path while fixing Linux dependencies and artifacts

## Testing
- `cmake -S projects/CMake -B build/test -DCMAKE_BUILD_TYPE=Release` *(fails: dependency/rlottie submodule not present in container)*

------
https://chatgpt.com/codex/tasks/task_e_68cd903db228832fbe96d9f3b475d0ef